### PR TITLE
0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1](https://github.com/LebJe/toml.lua/releases/tag/0.4.1) - 2024-11-19
+
+### Fixed
+- The formatting options that were passed as a parameter to `toml.encode`, `toml.encodeToFile`, `toml.toJSON`, and `toml.toYAML` previously had no effect when overriding values.
+- Resolved CMake `FetchContent_Populate` warning.
+
+### Changed
+-   Updated to magic_enum v0.9.7.
+
+### Added
+- Added tests for encoding options.
+
 ## [0.4.0](https://github.com/LebJe/toml.lua/releases/tag/0.4.0) - 2024-01-02
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,27 +57,24 @@ FetchContent_Declare(
 	GIT_REPOSITORY "https://github.com/Neargye/magic_enum.git"
 	GIT_SHALLOW ON
     GIT_SUBMODULES ""
-	GIT_TAG "v0.9.5"
+	GIT_TAG "v0.9.7"
 )
 
 FetchContent_GetProperties(${TOML++})
 if(NOT ${TOML++}_POPULATED)
     message(STATUS "Cloning ${TOML++}")
-	#FetchContent_Populate(${TOML++}) 
     FetchContent_MakeAvailable(${TOML++})
 endif()
 
 FetchContent_GetProperties(${SOL2})
 if(NOT ${SOL2}_POPULATED)
     message(STATUS "Cloning ${SOL2}")
-	FetchContent_Populate(${SOL2})
     FetchContent_MakeAvailable(${SOL2})
 endif()
 
 FetchContent_GetProperties(${MAGIC_ENUM})
 if(NOT ${MAGIC_ENUM}_POPULATED)
     message(STATUS "Cloning ${MAGIC_ENUM}")
-	FetchContent_Populate(${MAGIC_ENUM})
     FetchContent_MakeAvailable(${MAGIC_ENUM})
 endif()
 

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ int3 = 0x169F
 
 #### Formatting TOML, JSON, or YAML
 
-`toml.encode`, `toml.encodeToFile`, `toml.toJSON`, and `toml.toYAML` all take an optional second parameter: a table containing keys that disable or enable different formatting options.
+`toml.encode`, `toml.encodeToFile`, `toml.toJSON`, and `toml.toYAML` all take an optional second (third in the case of `toml.encodeToFile`) parameter: a table containing keys that disable or enable different formatting options.
 Passing an empty table removes all options, while not providing a table will use the default options.
 
 ```lua
@@ -514,10 +514,10 @@ Passing an empty table removes all options, while not providing a table will use
 	allowHexadecimalIntegers = true,
 
 	--- Apply indentation to tables nested within other tables/arrays.
-	indentSubTables = true,
+	indentSubTables = false,
 
 	--- Apply indentation to array elements when the array is forced to wrap over multiple lines.
-	indentArrayElements = true,
+	indentArrayElements = false,
 
 	--- Combination of `indentSubTables` and `indentArrayElements`.
 	indentation = true,

--- a/scripts/buildLuaJIT.ps1
+++ b/scripts/buildLuaJIT.ps1
@@ -17,9 +17,10 @@ New-Item -Path $installDir -ItemType "directory" -Name "include"
 New-Item -Path $installDir -ItemType "directory" -Name "share"
 New-Item -Path $installDir -ItemType "directory" -Name "jit"
 
-git clone https://luajit.org/git/luajit.git LuaJIT_src
-
-Set-Location "LuaJIT_src"
+Invoke-WebRequest -Uri "https://github.com/LuaJIT/LuaJIT/archive/refs/tags/v2.1.ROLLING.tar.gz" -OutFile "LuaJIT.tar.gz"
+tar -xzvf "LuaJIT.tar.gz"
+Remove-Item "LuaJIT.tar.gz"
+Set-Location "LuaJIT-2.1.ROLLING"
 
 mingw32-make.exe
 
@@ -34,4 +35,4 @@ Copy-Item "src\luajit.exe" -Destination "$($installDir)\bin"
 Copy-Item "src\lua51.dll" -Destination "$($installDir)\bin"
 
 Set-Location "$($pwd.Path)\.."
-Remove-Item -Recurse -Force "LuaJIT_src"
+Remove-Item -Recurse -Force "LuaJIT-2.1.ROLLING"

--- a/scripts/buildLuaJIT.ps1
+++ b/scripts/buildLuaJIT.ps1
@@ -17,9 +17,9 @@ New-Item -Path $installDir -ItemType "directory" -Name "include"
 New-Item -Path $installDir -ItemType "directory" -Name "share"
 New-Item -Path $installDir -ItemType "directory" -Name "jit"
 
-git clone https://luajit.org/git/luajit.git --branch v2.1 --depth 1
+git clone https://luajit.org/git/luajit.git LuaJIT-git --branch v2.1 --depth 1
 
-Set-Location "luajit"
+Set-Location "LuaJIT-git"
 
 mingw32-make.exe
 
@@ -34,4 +34,4 @@ Copy-Item "src\luajit.exe" -Destination "$($installDir)\bin"
 Copy-Item "src\lua51.dll" -Destination "$($installDir)\bin"
 
 Set-Location "$($pwd.Path)\.."
-Remove-Item -Recurse -Force "luajit"
+Remove-Item -Recurse -Force "LuaJIT-git"

--- a/scripts/buildLuaJIT.ps1
+++ b/scripts/buildLuaJIT.ps1
@@ -17,9 +17,9 @@ New-Item -Path $installDir -ItemType "directory" -Name "include"
 New-Item -Path $installDir -ItemType "directory" -Name "share"
 New-Item -Path $installDir -ItemType "directory" -Name "jit"
 
-git clone https://luajit.org/git/luajit.git LuaJIT-git --branch v2.1
+git clone https://luajit.org/git/luajit.git LuaJIT_src
 
-Set-Location "LuaJIT-git"
+Set-Location "LuaJIT_src"
 
 mingw32-make.exe
 
@@ -34,4 +34,4 @@ Copy-Item "src\luajit.exe" -Destination "$($installDir)\bin"
 Copy-Item "src\lua51.dll" -Destination "$($installDir)\bin"
 
 Set-Location "$($pwd.Path)\.."
-Remove-Item -Recurse -Force "LuaJIT-git"
+Remove-Item -Recurse -Force "LuaJIT_src"

--- a/scripts/buildLuaJIT.ps1
+++ b/scripts/buildLuaJIT.ps1
@@ -17,10 +17,9 @@ New-Item -Path $installDir -ItemType "directory" -Name "include"
 New-Item -Path $installDir -ItemType "directory" -Name "share"
 New-Item -Path $installDir -ItemType "directory" -Name "jit"
 
-Invoke-WebRequest -Uri "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz" -OutFile "LuaJIT.tar.gz"
-tar -xzvf "LuaJIT.tar.gz"
-Remove-Item "LuaJIT.tar.gz"
-Set-Location "LuaJIT-2.1.0-beta3"
+git clone https://luajit.org/git/luajit.git --branch v2.1 --depth 1
+
+Set-Location "luajit"
 
 mingw32-make.exe
 
@@ -35,4 +34,4 @@ Copy-Item "src\luajit.exe" -Destination "$($installDir)\bin"
 Copy-Item "src\lua51.dll" -Destination "$($installDir)\bin"
 
 Set-Location "$($pwd.Path)\.."
-Remove-Item -Recurse -Force "LuaJit-2.1.0-beta3"
+Remove-Item -Recurse -Force "luajit"

--- a/scripts/buildLuaJIT.ps1
+++ b/scripts/buildLuaJIT.ps1
@@ -17,7 +17,7 @@ New-Item -Path $installDir -ItemType "directory" -Name "include"
 New-Item -Path $installDir -ItemType "directory" -Name "share"
 New-Item -Path $installDir -ItemType "directory" -Name "jit"
 
-git clone https://luajit.org/git/luajit.git LuaJIT-git --branch v2.1 --depth 1
+git clone https://luajit.org/git/luajit.git LuaJIT-git --branch v2.1
 
 Set-Location "LuaJIT-git"
 

--- a/scripts/buildLuaRocks.sh
+++ b/scripts/buildLuaRocks.sh
@@ -2,7 +2,7 @@
 
 sudo apt install build-essential libreadline-dev unzip wget
 wget https://luarocks.org/releases/luarocks-3.11.0.tar.gz
-tar -zxpf luarocks-3.811.0.tar.gz
+tar -zxpf luarocks-3.11.0.tar.gz
 rm luarocks-3.11.0.tar.gz
 cd luarocks-3.11.0
 ./configure

--- a/scripts/buildLuaRocks.sh
+++ b/scripts/buildLuaRocks.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 sudo apt install build-essential libreadline-dev unzip wget
-wget https://luarocks.org/releases/luarocks-3.8.0.tar.gz
-tar -zxpf luarocks-3.8.0.tar.gz
-rm luarocks-3.8.0.tar.gz
-cd luarocks-3.8.0
+wget https://luarocks.org/releases/luarocks-3.11.0.tar.gz
+tar -zxpf luarocks-3.811.0.tar.gz
+rm luarocks-3.11.0.tar.gz
+cd luarocks-3.11.0
 ./configure
 make
 sudo make install

--- a/scripts/installLuaRocks.ps1
+++ b/scripts/installLuaRocks.ps1
@@ -9,10 +9,10 @@ if (-not (Test-Path -Path $installDir)) {
 
 $installDir = Resolve-Path $installDir
 
-Invoke-WebRequest -Uri "http://luarocks.github.io/luarocks/releases/luarocks-3.8.0-windows-32.zip" -OutFile "luarocks.zip"
+Invoke-WebRequest -Uri "http://luarocks.github.io/luarocks/releases/luarocks-3.11.0-windows-32.zip" -OutFile "luarocks.zip"
 Expand-Archive -Path "luarocks.zip" -DestinationPath "."
-Move-Item -Path "luarocks-3.8.0-windows-32\luarocks.exe" -Destination "$($installDir)"
-Move-Item -Path "luarocks-3.8.0-windows-32\luarocks-admin.exe" -Destination "$($installDir)"
+Move-Item -Path "luarocks-3.11.0-windows-32\luarocks.exe" -Destination "$($installDir)"
+Move-Item -Path "luarocks-3.11.0-windows-32\luarocks-admin.exe" -Destination "$($installDir)"
 
 Remove-Item "luarocks.zip"
-Remove-Item -Recurse -Force "luarocks-3.8.0-windows-32"
+Remove-Item -Recurse -Force "luarocks-3.11.0-windows-32"

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -93,26 +93,6 @@ inline toml::format_flags defaultFormatFlags() {
 	return flags;
 }
 
-// void addFlag(toml::format_flags & flags, sol::table & flagsTable, toml::format_flags flagToAdd) {
-// 	auto tableFlag = flagsTable[camelCase(magic_enum::enum_name(flagToAdd))];
-
-// 	std::cout << "addFlag: \nenum_name: " << magic_enum::enum_name(flagToAdd) << "\n";
-	
-// 	std::cout << "camel case name: " << camelCase(magic_enum::enum_name(flagToAdd)) << "\n";
-
-// 	if (tableFlag.valid()) {
-// 		std::cout << "Is valid: " << camelCase(magic_enum::enum_name(flagToAdd)) << "\n";
-// 		if (tableFlag.get<bool>()) {
-// 			flags |= flagToAdd;
-// 		}
-// 	} else {
-// 		// Use default
-// 		if (defaultFlags[flagToAdd]) {
-// 			flags |= flagToAdd;
-// 		}
-// 	};
-// }
-
 toml::format_flags tableToFormatFlags(sol::optional<sol::table> t) {
 	auto flags = format_flags::none;
 
@@ -126,9 +106,6 @@ toml::format_flags tableToFormatFlags(sol::optional<sol::table> t) {
 
 	// User passed an empty table to clear all flags.
 	if (table.empty()) return flags;
-	
-	// Set default flags, and allow user to override
-	//flags = defaultFormatFlags();
 	
 	// Set default flags, and allow user to override
 	std::map<format_flags, bool> userFlags = defaultFlags;
@@ -145,25 +122,9 @@ toml::format_flags tableToFormatFlags(sol::optional<sol::table> t) {
 		userFlags[toml::format_flags::indentation] = table["indentation"].get<bool>();
 	}
 	
-	std::cout << "UserFlags:\n";
-	
-	for (auto [flag, enabled] : userFlags) {
-		std::cout << "Flag: " << magic_enum::enum_name(flag) << ", Enabled: " << (enabled ? "True" : "False") << "\n";
-	}
-	
 	for (auto [flag, enabled] : userFlags) {
 		if (enabled) flags |= flag;
 	}
-	
-	// constexpr auto f = magic_enum::enum_values<format_flags>();
-	// for (auto flag : f) {
-	// 	addFlag(flags, table, flag);
-	// }
-
-	// // `format_flags::indentation` is not returned from `enum_values`, so we must handle it separately.
-	// if (table["indentation"].valid()) {
-	// 	flags |= toml::format_flags::indentation;
-	// }
 	
 	return flags;
 }

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -19,6 +19,7 @@ static std::map<format_flags, bool> defaultFlags =
 										 { format_flags::allow_hexadecimal_integers, true },
 										 { format_flags::allow_octal_integers, true },
 										 { format_flags::indent_sub_tables, false },
+										 { format_flags::indent_array_elements, false },
 										 { format_flags::indentation, true },
 										 { format_flags::relaxed_float_precision, false },
 										 { format_flags::terse_key_value_pairs, false } };
@@ -92,19 +93,28 @@ inline toml::format_flags defaultFormatFlags() {
 	return flags;
 }
 
-void addFlag(toml::format_flags & flags, sol::table & flagsTable, toml::format_flags flagToAdd) {
-	auto tableFlag = flagsTable[camelCase(magic_enum::enum_name(flagToAdd))];
+// void addFlag(toml::format_flags & flags, sol::table & flagsTable, toml::format_flags flagToAdd) {
+// 	auto tableFlag = flagsTable[camelCase(magic_enum::enum_name(flagToAdd))];
 
-	if (tableFlag.valid()) {
-		flags |= tableFlag.get<bool>() ? flagToAdd : flags;
-	} else {
-		// Use default
-		flags |= defaultFlags[flagToAdd] ? flagToAdd : flags;
-	};
-}
+// 	std::cout << "addFlag: \nenum_name: " << magic_enum::enum_name(flagToAdd) << "\n";
+	
+// 	std::cout << "camel case name: " << camelCase(magic_enum::enum_name(flagToAdd)) << "\n";
+
+// 	if (tableFlag.valid()) {
+// 		std::cout << "Is valid: " << camelCase(magic_enum::enum_name(flagToAdd)) << "\n";
+// 		if (tableFlag.get<bool>()) {
+// 			flags |= flagToAdd;
+// 		}
+// 	} else {
+// 		// Use default
+// 		if (defaultFlags[flagToAdd]) {
+// 			flags |= flagToAdd;
+// 		}
+// 	};
+// }
 
 toml::format_flags tableToFormatFlags(sol::optional<sol::table> t) {
-	auto flags = format_flags();
+	auto flags = format_flags::none;
 
 	// Set default flags.
 	if (!t) {
@@ -116,14 +126,45 @@ toml::format_flags tableToFormatFlags(sol::optional<sol::table> t) {
 
 	// User passed an empty table to clear all flags.
 	if (table.empty()) return flags;
-
-	constexpr auto f = magic_enum::enum_values<format_flags>();
-	for (auto flag : f) {
-		addFlag(flags, table, flag);
+	
+	// Set default flags, and allow user to override
+	//flags = defaultFormatFlags();
+	
+	// Set default flags, and allow user to override
+	std::map<format_flags, bool> userFlags = defaultFlags;
+	
+	for (auto [flag, enabled] : userFlags) {
+		std::string camelCaseFlagName = camelCase(magic_enum::enum_name(flag));
+		if (table[camelCaseFlagName].valid()) {
+			userFlags[flag] = table[camelCaseFlagName].get<bool>();
+		}
 	}
+	
+	// `format_flags::indentation` is returned as an empty string from `magic_enum::enum_name`, so we must handle it separately.
+	if (table["indentation"].valid()) {
+		userFlags[toml::format_flags::indentation] = table["indentation"].get<bool>();
+	}
+	
+	std::cout << "UserFlags:\n";
+	
+	for (auto [flag, enabled] : userFlags) {
+		std::cout << "Flag: " << magic_enum::enum_name(flag) << ", Enabled: " << (enabled ? "True" : "False") << "\n";
+	}
+	
+	for (auto [flag, enabled] : userFlags) {
+		if (enabled) flags |= flag;
+	}
+	
+	// constexpr auto f = magic_enum::enum_values<format_flags>();
+	// for (auto flag : f) {
+	// 	addFlag(flags, table, flag);
+	// }
 
-	// `format_flags::indentation` is not returned from `enum_values`.
-	addFlag(flags, table, format_flags::indentation);
+	// // `format_flags::indentation` is not returned from `enum_values`, so we must handle it separately.
+	// if (table["indentation"].valid()) {
+	// 	flags |= toml::format_flags::indentation;
+	// }
+	
 	return flags;
 }
 

--- a/src/utilities/utilities.hpp
+++ b/src/utilities/utilities.hpp
@@ -12,7 +12,7 @@
 
 /// Converts a string into [Camel Case](https://en.wikipedia.org/wiki/Camel_case).
 ///
-/// The code in this function is based on https://en.wikipedia.org/wiki/Camel_case
+/// The code in this function is based on https://codereview.stackexchange.com/a/263761
 std::string camelCase(std::string s) noexcept;
 
 /// Version of `camelCase` that accepts a `string_view`.
@@ -36,7 +36,8 @@ std::string parseErrorToString(toml::parse_error e);
 /// Inserts the values in `e` into `table`.
 void parseErrorToTable(toml::parse_error e, sol::table & table);
 
-/// Takes a Lua table, with keys representing flag names, and values
+/// Takes a Lua table, with keys representing flag names, and values, and converts it to `toml::format_flags`. 
+/// If the table is nil, all format flags are set to their default value, if the table is empty, `toml::format_flags` is set to none.
 toml::format_flags tableToFormatFlags(sol::optional<sol::table> t);
 
 Options tableToOptions(sol::optional<sol::table> t);
@@ -54,5 +55,10 @@ std::optional<std::string> keyToString(sol::object key);
 ///
 /// If a string is not on the stack, then an integer from `luaL_argerror` is returned.
 std::variant<int, toml::table *> getTableFromStringInState(sol::state_view state, int index = 1);
+
+template <>
+struct magic_enum::customize::enum_range<toml::format_flags> {
+  static constexpr bool is_flags = true;
+};
 
 #endif /* UTILITIES_H */

--- a/tests/test-data/encoding/noIndentation.json
+++ b/tests/test-data/encoding/noIndentation.json
@@ -1,0 +1,38 @@
+{
+"database" : {
+"data" : [
+[
+"delta",
+"phi"
+],
+[
+3.1400000000000001
+]
+],
+"enabled" : true,
+"ports" : [
+8000,
+8001,
+8002
+],
+"temp_targets" : {
+"case" : 72,
+"cpu" : 79.5
+}
+},
+"owner" : {
+"dob" : "1979-05-27T07:32:00-08:00",
+"name" : "Tom Preston-Werner"
+},
+"servers" : {
+"alpha" : {
+"ip" : "10.0.0.1",
+"role" : "frontend"
+},
+"beta" : {
+"ip" : "10.0.0.2",
+"role" : "backend"
+}
+},
+"title" : "TOML Example"
+}

--- a/tests/test-data/encoding/terseKeys+qoutedTimestamps.toml
+++ b/tests/test-data/encoding/terseKeys+qoutedTimestamps.toml
@@ -1,0 +1,22 @@
+title="TOML Example"
+
+[database]
+data=[ [ "delta", "phi" ], [ 3.1400000000000001 ] ]
+enabled=true
+ports=[ 8000, 8001, 8002 ]
+
+    [database.temp_targets]
+    case=72
+    cpu=79.5
+
+[owner]
+dob="1979-05-27T07:32:00-08:00"
+name="Tom Preston-Werner"
+
+[servers.alpha]
+ip="10.0.0.1"
+role="frontend"
+
+[servers.beta]
+ip="10.0.0.2"
+role="backend"

--- a/tests/tests.lua
+++ b/tests/tests.lua
@@ -1,4 +1,4 @@
-lu = require("luaunit")
+local lu = require("luaunit")
 local toml = require("toml")
 local data = require("tests/tables")
 
@@ -27,6 +27,17 @@ end
 function TestEncoder:testEncodeMassiveTable()
 	local massive = read("tests/test-data/massive.toml")
 	lu.assertEquals(toml.encode(data.tableForMassiveToml), massive)
+end
+
+function TestEncoder:testEncodingOptions()
+	local terseKeysToml = read("tests/test-data/encoding/terseKeys+qoutedTimestamps.toml")
+
+	lu.assertEquals(toml.encode(toml.decode(terseKeysToml), { terseKeyValuePairs = true, quoteDatesAndTimes = true }), terseKeysToml)
+
+	local noIndentationJSON = read("tests/test-data/encoding/noIndentation.json")
+
+	lu.assertEquals(toml.toJSON(toml.decode(terseKeysToml), { indentation = false }), noIndentationJSON)
+	
 end
 
 function TestDecoder:testDecodeSamples()

--- a/toml-0.4.1-0.rockspec
+++ b/toml-0.4.1-0.rockspec
@@ -1,5 +1,5 @@
 package = "toml"
-version = "0.4.0-0"
+version = "0.4.1-0"
 
 local v = version:gsub("%-%d", "")
 

--- a/toml.d.tl
+++ b/toml.d.tl
@@ -20,7 +20,7 @@ local record toml
 	
 	--- Encodes a Lua table into a TOML document, and **appends** that document to a file.
 	--- @param data table: The Lua table to be encoded.
-	--- @param file string: The file to write the document to/
+	--- @param file string: The file to write the document to.
 	--- @param options FormattingOptions|nil: Options for formatting the YAML document. Pass `{}` to remove all options, or no table to use the default options.
 	encodeToFile: function(data: { string: any }, fileOrOptions: string|EncodeToFileOptions, options: FormattingOptions|nil)
 	


### PR DESCRIPTION
### Fixed
- The formatting options that were passed as a parameter to `toml.encode`, `toml.encodeToFile`, `toml.toJSON`, and `toml.toYAML` previously had no effect when overriding values.
- Resolved CMake `FetchContent_Populate` warning.

### Changed
-   Updated to magic_enum v0.9.7.

### Added
- Added tests for encoding options.
